### PR TITLE
Handle spaces in team and project

### DIFF
--- a/scripts/publish-sentry-release
+++ b/scripts/publish-sentry-release
@@ -219,10 +219,10 @@ while [ "$1" != "" ]; do
                         PLATFORM=$1
                         ;;
     -t | --team )       shift
-                        SENTRY_TEAM=$1
+                        SENTRY_TEAM=${1// /-}
                         ;;
     -P | --project )    shift
-                        SENTRY_PROJECT=$1
+                        SENTRY_PROJECT=${1// /-}
                         ;;
     -k | --auth-token ) shift
                         SENTRY_AUTH_TOKEN=$1


### PR DESCRIPTION
Script wasn't working for me cause I had a space in my project, but this fixes it by replacing spaces with dashes. Capitalization doesn't matter.